### PR TITLE
Fix personal access client not found error

### DIFF
--- a/fix_passport_asim_tenant.sql
+++ b/fix_passport_asim_tenant.sql
@@ -1,0 +1,70 @@
+-- SQL script to fix Passport OAuth clients for tenant 'asim'
+-- Tenant ID: d815f98d-82df-4e2f-95a6-0a66b30d0c62
+-- Database: tenantd815f98d-82df-4e2f-95a6-0a66b30d0c62 (or similar based on your tenant DB naming)
+
+-- First, connect to the tenant database
+-- USE tenantd815f98d-82df-4e2f-95a6-0a66b30d0c62;
+
+-- Check if personal access client already exists
+SELECT * FROM oauth_clients WHERE personal_access_client = 1;
+
+-- Check if password client already exists  
+SELECT * FROM oauth_clients WHERE password_client = 1;
+
+-- If no personal access client exists, create one
+INSERT INTO oauth_clients (
+    user_id, 
+    name, 
+    secret, 
+    provider, 
+    redirect, 
+    personal_access_client, 
+    password_client, 
+    revoked, 
+    created_at, 
+    updated_at
+) VALUES (
+    NULL,
+    'Laravel Personal Access Client',
+    'your-generated-secret-key-here',
+    'users',
+    'http://localhost',
+    1,
+    0,
+    0,
+    NOW(),
+    NOW()
+);
+
+-- Get the ID of the personal access client we just created (replace X with actual ID)
+-- INSERT INTO oauth_personal_access_clients (client_id, created_at, updated_at) 
+-- VALUES (X, NOW(), NOW());
+
+-- If no password client exists, create one
+INSERT INTO oauth_clients (
+    user_id, 
+    name, 
+    secret, 
+    provider, 
+    redirect, 
+    personal_access_client, 
+    password_client, 
+    revoked, 
+    created_at, 
+    updated_at
+) VALUES (
+    NULL,
+    'Laravel Password Grant Client',
+    'your-generated-secret-key-here-2',
+    'users',
+    'http://localhost',
+    0,
+    1,
+    0,
+    NOW(),
+    NOW()
+);
+
+-- Verify the clients were created
+SELECT id, name, personal_access_client, password_client, provider FROM oauth_clients;
+SELECT * FROM oauth_personal_access_clients;

--- a/install_passport_commands.md
+++ b/install_passport_commands.md
@@ -1,0 +1,66 @@
+# Commands to Fix Passport for Tenant 'asim'
+
+## Tenant Information
+- **Tenant ID**: `d815f98d-82df-4e2f-95a6-0a66b30d0c62`
+- **Domain**: `asim.127.0.0.1.nip.io`
+- **Tenant Database**: Likely `tenantd815f98d-82df-4e2f-95a6-0a66b30d0c62` (based on your tenancy config)
+
+## Solution 1: Using Artisan Commands (Recommended)
+
+If you have access to run artisan commands:
+
+```bash
+# Option A: Use the tenant:artisan command
+php artisan tenant:artisan --tenant=d815f98d-82df-4e2f-95a6-0a66b30d0c62 passport:install --force
+
+# Option B: Use the existing controller route
+# Make a POST request to: http://127.0.0.1:8000/tenants/d815f98d-82df-4e2f-95a6-0a66b30d0c62/passport-install
+curl -X POST "http://127.0.0.1:8000/tenants/d815f98d-82df-4e2f-95a6-0a66b30d0c62/passport-install"
+```
+
+## Solution 2: Using the PHP Script
+
+If you can run PHP:
+
+```bash
+# First install dependencies (if not already done)
+composer install
+
+# Run the script
+php install_passport_for_tenant.php
+```
+
+## Solution 3: Direct Database Access
+
+If you have MySQL/database access, connect to the tenant database and run the SQL script:
+
+```bash
+# Connect to your tenant database
+mysql -u your_username -p tenantd815f98d-82df-4e2f-95a6-0a66b30d0c62
+
+# Then run the SQL commands from fix_passport_asim_tenant.sql
+```
+
+## Solution 4: Quick Fix via Tinker
+
+```bash
+php artisan tinker
+
+# In tinker, run:
+$tenant = App\Models\Tenant::find('d815f98d-82df-4e2f-95a6-0a66b30d0c62');
+tenancy()->initialize($tenant);
+Artisan::call('passport:install', ['--force' => true]);
+tenancy()->end();
+```
+
+## Verification
+
+After running any of the above solutions, test your login:
+
+```bash
+curl -X POST http://asim.127.0.0.1.nip.io:8000/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "your-email@example.com", "password": "your-password"}'
+```
+
+The error should be resolved and you should get a successful authentication response.

--- a/install_passport_for_tenant.php
+++ b/install_passport_for_tenant.php
@@ -14,11 +14,12 @@ use Illuminate\Support\Facades\Schema;
 echo "Starting Passport installation for tenant 'asim'...\n";
 
 try {
-    // Find the tenant by domain
-    $tenant = Tenant::where('domain', 'asim.127.0.0.1.nip.io')->first();
+    // Find the tenant by ID (we know it's d815f98d-82df-4e2f-95a6-0a66b30d0c62)
+    $tenantId = 'd815f98d-82df-4e2f-95a6-0a66b30d0c62';
+    $tenant = Tenant::find($tenantId);
     
     if (!$tenant) {
-        echo "ERROR: Tenant with domain 'asim.127.0.0.1.nip.io' not found!\n";
+        echo "ERROR: Tenant with ID '{$tenantId}' not found!\n";
         echo "Available tenants:\n";
         $allTenants = Tenant::all();
         foreach ($allTenants as $t) {

--- a/install_passport_for_tenant.php
+++ b/install_passport_for_tenant.php
@@ -1,0 +1,119 @@
+<?php
+
+require_once 'vendor/autoload.php';
+
+// Bootstrap Laravel
+$app = require_once 'bootstrap/app.php';
+$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+
+use App\Models\Tenant;
+use Laravel\Passport\Passport;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+echo "Starting Passport installation for tenant 'asim'...\n";
+
+try {
+    // Find the tenant by domain
+    $tenant = Tenant::where('domain', 'asim.127.0.0.1.nip.io')->first();
+    
+    if (!$tenant) {
+        echo "ERROR: Tenant with domain 'asim.127.0.0.1.nip.io' not found!\n";
+        echo "Available tenants:\n";
+        $allTenants = Tenant::all();
+        foreach ($allTenants as $t) {
+            echo "- ID: {$t->id}, Domain: {$t->domain}\n";
+        }
+        exit(1);
+    }
+    
+    echo "Found tenant: ID {$tenant->id}, Domain: {$tenant->domain}\n";
+    
+    // Initialize tenancy
+    tenancy()->initialize($tenant);
+    
+    try {
+        echo "Tenancy initialized. Installing Passport...\n";
+        
+        // Check if oauth_clients table exists
+        if (!Schema::hasTable('oauth_clients')) {
+            echo "ERROR: oauth_clients table not found in tenant database!\n";
+            echo "Please run tenant migrations first.\n";
+            exit(1);
+        }
+        
+        // Check if personal access client already exists
+        $personalClient = DB::table('oauth_clients')
+            ->where('personal_access_client', true)
+            ->first();
+            
+        if ($personalClient) {
+            echo "Personal access client already exists (ID: {$personalClient->id})\n";
+        } else {
+            echo "Creating personal access client...\n";
+            
+            // Create personal access client
+            $clientId = DB::table('oauth_clients')->insertGetId([
+                'user_id' => null,
+                'name' => 'Laravel Personal Access Client',
+                'secret' => \Illuminate\Support\Str::random(40),
+                'provider' => 'users',
+                'redirect' => 'http://localhost',
+                'personal_access_client' => true,
+                'password_client' => false,
+                'revoked' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            
+            // Create personal access client record
+            DB::table('oauth_personal_access_clients')->insert([
+                'client_id' => $clientId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            
+            echo "Personal access client created with ID: {$clientId}\n";
+        }
+        
+        // Check if password client exists
+        $passwordClient = DB::table('oauth_clients')
+            ->where('password_client', true)
+            ->first();
+            
+        if ($passwordClient) {
+            echo "Password client already exists (ID: {$passwordClient->id})\n";
+        } else {
+            echo "Creating password client...\n";
+            
+            // Create password client
+            $clientId = DB::table('oauth_clients')->insertGetId([
+                'user_id' => null,
+                'name' => 'Laravel Password Grant Client',
+                'secret' => \Illuminate\Support\Str::random(40),
+                'provider' => 'users',
+                'redirect' => 'http://localhost',
+                'personal_access_client' => false,
+                'password_client' => true,
+                'revoked' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            
+            echo "Password client created with ID: {$clientId}\n";
+        }
+        
+        echo "Passport installation completed successfully!\n";
+        
+    } finally {
+        // End tenancy
+        tenancy()->end();
+    }
+    
+} catch (Exception $e) {
+    echo "ERROR: " . $e->getMessage() . "\n";
+    echo "Stack trace:\n" . $e->getTraceAsString() . "\n";
+    exit(1);
+}
+
+echo "Done!\n";


### PR DESCRIPTION
Add a script to programmatically create Laravel Passport OAuth clients for a specific tenant.

The "Personal access client not found" error in multi-tenant Laravel Passport applications occurs when the required OAuth clients are missing for a specific tenant. This script provides a way to create these clients programmatically for a given tenant, which is necessary because the standard `passport:install` command needs to be run within the tenant's context.

---
<a href="https://cursor.com/background-agent?bcId=bc-f19fd54f-194b-45f7-ab4e-615c818a4bd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f19fd54f-194b-45f7-ab4e-615c818a4bd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

